### PR TITLE
Support Xcode9.1 - Swift 4

### DIFF
--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -31,20 +31,20 @@
 		1E8FA0221870D7FF3F13C9577AE382B0 /* Pods-SwiftMaskTextFieldDemo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftMaskTextFieldDemo-frameworks.sh"; sourceTree = "<group>"; };
 		2BDB9BD8F77BC20ED937E7765461E534 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		332A75BE9E41D915D4F3826CF0D585F8 /* Pods-SwiftMaskTextFieldDemo-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SwiftMaskTextFieldDemo-umbrella.h"; sourceTree = "<group>"; };
-		3985DB0211565D1CD23D85F87B86BE88 /* SwiftMaskTextField.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = SwiftMaskTextField.modulemap; sourceTree = "<group>"; };
+		3985DB0211565D1CD23D85F87B86BE88 /* SwiftMaskTextField.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftMaskTextField.modulemap; sourceTree = "<group>"; };
 		404A10B15EBD86CAF0A324CE4AAD8FAA /* SwiftMaskTextField-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftMaskTextField-dummy.m"; sourceTree = "<group>"; };
-		4513806FC7C36BDE6FC93D0EA1D2CAED /* Pods_SwiftMaskTextFieldDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SwiftMaskTextFieldDemo.framework; path = "Pods-SwiftMaskTextFieldDemo.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4513806FC7C36BDE6FC93D0EA1D2CAED /* Pods_SwiftMaskTextFieldDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftMaskTextFieldDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		6FA8268558F96F77F428D56C7ECE44F4 /* SwiftMaskTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftMaskTextField.swift; sourceTree = "<group>"; };
 		72A1C7262EC5782743D7B6D4D6D345F8 /* Pods-SwiftMaskTextFieldDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SwiftMaskTextFieldDemo-acknowledgements.plist"; sourceTree = "<group>"; };
 		7EA6F45F4321B321379B95F881FD2E74 /* SwiftMaskTextField-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftMaskTextField-umbrella.h"; sourceTree = "<group>"; };
 		8C4C7BADB900B48B2CB0AEEF8C23436D /* Pods-SwiftMaskTextFieldDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SwiftMaskTextFieldDemo.release.xcconfig"; sourceTree = "<group>"; };
 		8F27112A69AF3357803915675E6C7A05 /* SwiftMaskTextField.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftMaskTextField.xcconfig; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		99C612DC18F1A07BA2838018A403D179 /* SwiftMaskTextField.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SwiftMaskTextField.framework; path = SwiftMaskTextField.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		99C612DC18F1A07BA2838018A403D179 /* SwiftMaskTextField.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMaskTextField.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A27558CAC988280768421232AB03C9FF /* Pods-SwiftMaskTextFieldDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SwiftMaskTextFieldDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
 		BC5E0F57592667049F36A86B1971A60A /* Pods-SwiftMaskTextFieldDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SwiftMaskTextFieldDemo-dummy.m"; sourceTree = "<group>"; };
-		DA993BE78C71E1D1063D93A362820FF5 /* Pods-SwiftMaskTextFieldDemo.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-SwiftMaskTextFieldDemo.modulemap"; sourceTree = "<group>"; };
+		DA993BE78C71E1D1063D93A362820FF5 /* Pods-SwiftMaskTextFieldDemo.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SwiftMaskTextFieldDemo.modulemap"; sourceTree = "<group>"; };
 		DF425E9D99878B5DCCCB32EBE1217C9A /* Pods-SwiftMaskTextFieldDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SwiftMaskTextFieldDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		EF5841649795D52C5AC84B24D6984BBC /* Pods-SwiftMaskTextFieldDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftMaskTextFieldDemo-resources.sh"; sourceTree = "<group>"; };
 		EF89B757BDA9E6AD948FEF909FFFCCFD /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -75,7 +75,6 @@
 			children = (
 				6FA8268558F96F77F428D56C7ECE44F4 /* SwiftMaskTextField.swift */,
 			);
-			name = Core;
 			path = Core;
 			sourceTree = "<group>";
 		};
@@ -84,7 +83,6 @@
 			children = (
 				2357F6BB73ECD2923939A79C438D5E59 /* Core */,
 			);
-			name = Sources;
 			path = Sources;
 			sourceTree = "<group>";
 		};
@@ -171,7 +169,6 @@
 			children = (
 				2EAFB05AE6C1182EC0F03E8C43FD510B /* Sources */,
 			);
-			name = "swift-mask-textfield";
 			path = "swift-mask-textfield";
 			sourceTree = "<group>";
 		};
@@ -344,6 +341,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PROVISIONING_PROFILE_SPECIFIER = NO_SIGNING/;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_VERSION = 4.0;
 				SYMROOT = "${SRCROOT}/../build";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -453,7 +451,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -488,7 +486,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -539,6 +537,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PROVISIONING_PROFILE_SPECIFIER = NO_SIGNING/;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_VERSION = 4.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};
 			name = Debug;

--- a/Demo/SwiftMaskTextFieldDemo.xcodeproj/project.pbxproj
+++ b/Demo/SwiftMaskTextFieldDemo.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -326,6 +327,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -376,6 +378,7 @@
 				B97324D71E13F4E9007C6D68 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SwiftMaskTextfield.podspec
+++ b/SwiftMaskTextfield.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.name         = "SwiftMaskTextField"
+  s.name         = "SwiftMaskTextfield"
   s.version      = "0.0.4"
   s.summary      = "An TextField with masking capabilities"
 

--- a/swift-mask-textfield/Sources/Core/SwiftMaskTextField.swift
+++ b/swift-mask-textfield/Sources/Core/SwiftMaskTextField.swift
@@ -179,13 +179,13 @@ open class SwiftMaskTextField : UITextField {
             
             currentTextForFormatting = self.getFilteredString(currentTextForFormatting)
             
-            if currentTextForFormatting.characters.count > 0 {
+            if currentTextForFormatting.count > 0 {
                 while true {
                     let formatPatternRange = formatterIndex ..< formatPattern.index(after: formatterIndex)
-                    let currentFormatCharacter = self.formatPattern.substring(with: formatPatternRange)
+                    let currentFormatCharacter = String(self.formatPattern[formatPatternRange])
                     
                     let currentTextForFormattingPatterRange = currentTextForFormattingIndex ..< currentTextForFormatting.index(after: currentTextForFormattingIndex)
-                    let currentTextForFormattingCharacter = currentTextForFormatting.substring(with: currentTextForFormattingPatterRange)
+                    let currentTextForFormattingCharacter = String(currentTextForFormatting[currentTextForFormattingPatterRange])
                     
                     switch currentFormatCharacter {
                         case self.lettersAndDigitsReplacementChar:

--- a/swift-mask-textfield/Sources/Core/SwiftMaskTextField.swift
+++ b/swift-mask-textfield/Sources/Core/SwiftMaskTextField.swift
@@ -68,7 +68,7 @@ open class SwiftMaskTextField : UITextField {
      */
     open var maxLength: Int {
         get {
-            return formatPattern.characters.count
+            return formatPattern.count
         }
     }
     
@@ -168,7 +168,7 @@ open class SwiftMaskTextField : UITextField {
         var currentTextForFormatting = ""
         
         if let text = super.text {
-            if text.characters.count > 0 {
+            if text.count > 0 {
                 currentTextForFormatting = text
             }
         }
@@ -234,8 +234,8 @@ open class SwiftMaskTextField : UITextField {
             super.text = finalText
             
             if let text = self.text {
-                if text.characters.count > self.maxLength {
-                    super.text = text.substring(to: text.characters.index(text.startIndex, offsetBy: self.maxLength))
+                if text.count > self.maxLength {
+                    super.text = String(text[text.index(text.startIndex, offsetBy: self.maxLength)])
                 }
             }
         }


### PR DESCRIPTION
This includes the following changes and fixes:

- And update `SWIFT_VERSION` to Swift 4
- Fix `characters` deprecated warning
- Use String slicing instead substring( )
- Update SwiftMaskTextfield.podspec: Update `s.name` from `SwiftMaskTextField` to `SwiftMaskTextfield`