### PR TITLE
Update Demo and Lib to Swift5

### DIFF
--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -31,22 +31,22 @@
 		3F0C8992624C397BBB9A70B81203AD97 /* SwiftMaskTextfield.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftMaskTextfield.swift; path = "swift-mask-textfield/Sources/Core/SwiftMaskTextfield.swift"; sourceTree = "<group>"; };
 		40694EC6A08EB8CD0C150BB9EE32666C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		46022A1736D0F0093B29FA72F39997E6 /* Pods-SwiftMaskTextFieldDemo.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SwiftMaskTextFieldDemo.modulemap"; sourceTree = "<group>"; };
-		505B50F5F1DB023733CD21C5A48ECC08 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		505B50F5F1DB023733CD21C5A48ECC08 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		5B0380B2712C42D9B09459318C3DEE67 /* Pods-SwiftMaskTextFieldDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SwiftMaskTextFieldDemo.release.xcconfig"; sourceTree = "<group>"; };
 		5D1F41E015BA9279AF5D87FC30EEE62D /* SwiftMaskTextfield-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftMaskTextfield-prefix.pch"; sourceTree = "<group>"; };
 		651E623D65F6624A11B083509BAAF17A /* SwiftMaskTextfield-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SwiftMaskTextfield-dummy.m"; sourceTree = "<group>"; };
 		6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		6656F5DF62049D08DDA305A47F43A37F /* Pods-SwiftMaskTextFieldDemo-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftMaskTextFieldDemo-frameworks.sh"; sourceTree = "<group>"; };
-		68C9182B53B0FA65B6757421C2781A9A /* SwiftMaskTextfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SwiftMaskTextfield.framework; path = SwiftMaskTextfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		698530AA63C2F509C1A47442E4383323 /* Pods_SwiftMaskTextFieldDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SwiftMaskTextFieldDemo.framework; path = "Pods-SwiftMaskTextFieldDemo.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		68C9182B53B0FA65B6757421C2781A9A /* SwiftMaskTextfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftMaskTextfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		698530AA63C2F509C1A47442E4383323 /* Pods_SwiftMaskTextFieldDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftMaskTextFieldDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A1F8DBCF8D491C22584A254EAE9D2D8 /* SwiftMaskTextfield.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftMaskTextfield.xcconfig; sourceTree = "<group>"; };
 		6CE942303C124136F0234C7682BBCE87 /* SwiftMaskTextfield-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftMaskTextfield-umbrella.h"; sourceTree = "<group>"; };
-		6D75773C3B0F7249F12EAF996E6F6BAD /* LICENSE.md */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE.md; sourceTree = "<group>"; };
+		6D75773C3B0F7249F12EAF996E6F6BAD /* LICENSE.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		8540E3EA76873E7EE39EE0089A262A46 /* Pods-SwiftMaskTextFieldDemo-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SwiftMaskTextFieldDemo-umbrella.h"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A40A5883A4432F59F0A43A14FD2CAEBE /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A788AA78748439EA05F354D3D2D4CBF7 /* Pods-SwiftMaskTextFieldDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SwiftMaskTextFieldDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		AE53A11AA6DC327A57899331D7CFDDE1 /* SwiftMaskTextfield.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = SwiftMaskTextfield.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		AE53A11AA6DC327A57899331D7CFDDE1 /* SwiftMaskTextfield.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = SwiftMaskTextfield.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		CB22DD656ADB001A9E5AB9C16E120822 /* Pods-SwiftMaskTextFieldDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SwiftMaskTextFieldDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
 		E3FC0C8795C84E502FCF7C20293E7177 /* SwiftMaskTextfield.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SwiftMaskTextfield.modulemap; sourceTree = "<group>"; };
 		F5EE76313AC55835D6B31D1A21D6410D /* Pods-SwiftMaskTextFieldDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SwiftMaskTextFieldDemo-resources.sh"; sourceTree = "<group>"; };
@@ -242,14 +242,15 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1160;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
 			productRefGroup = BD6FED90C038AA28D2E7C6A45AC3AE69 /* Products */;
@@ -296,6 +297,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -494,6 +496,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -243,6 +243,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 1160;
+				TargetAttributes = {
+					9C32DB78463C1544BAA4A1D48D2AA827 = {
+						LastSwiftMigration = 1160;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -417,7 +422,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -484,7 +489,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Demo/SwiftMaskTextFieldDemo.xcodeproj/project.pbxproj
+++ b/Demo/SwiftMaskTextFieldDemo.xcodeproj/project.pbxproj
@@ -117,20 +117,20 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1160;
 				ORGANIZATIONNAME = GabrielMackoz;
 				TargetAttributes = {
 					B97324C21E13F4E9007C6D68 = {
 						CreatedOnToolsVersion = 8.2;
 						DevelopmentTeam = FU7J9F5JA8;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1160;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = B97324BE1E13F4E9007C6D68 /* Build configuration list for PBXProject "SwiftMaskTextFieldDemo" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -234,6 +234,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -293,6 +294,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -351,7 +353,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gabrielmackoz.SwiftMaskTextFieldDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -365,7 +367,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.gabrielmackoz.SwiftMaskTextFieldDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SwiftMaskTextfield.podspec
+++ b/SwiftMaskTextfield.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name         = "SwiftMaskTextfield"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.summary      = "An TextField with masking capabilities"
 
   s.description  = <<-DESC

--- a/swift-mask-textfield.xcodeproj/project.pbxproj
+++ b/swift-mask-textfield.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1160;
 				ORGANIZATIONNAME = gabrielmackoz;
 				TargetAttributes = {
 					3338E86D1D809CC100767E4B = {
@@ -195,10 +195,11 @@
 			};
 			buildConfigurationList = 3338E8681D809CC100767E4B /* Build configuration list for PBXProject "swift-mask-textfield" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 3338E8641D809CC100767E4B;
 			productRefGroup = 3338E86F1D809CC100767E4B /* Products */;
@@ -260,6 +261,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -319,6 +321,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/swift-mask-textfield.xcodeproj/project.pbxproj
+++ b/swift-mask-textfield.xcodeproj/project.pbxproj
@@ -184,12 +184,12 @@
 					3338E86D1D809CC100767E4B = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = FU7J9F5JA8;
-						LastSwiftMigration = "";
+						LastSwiftMigration = 1160;
 					};
 					3338E8771D809CC100767E4B = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = FU7J9F5JA8;
-						LastSwiftMigration = "";
+						LastSwiftMigration = 1160;
 					};
 				};
 			};
@@ -385,7 +385,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gabrielmackoz.swift-mask-textfield";
 				PRODUCT_NAME = SwiftMaskTextField;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -403,7 +403,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gabrielmackoz.swift-mask-textfield";
 				PRODUCT_NAME = SwiftMaskTextField;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -414,7 +414,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gabrielmackoz.swift-mask-textfieldTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -425,7 +425,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.gabrielmackoz.swift-mask-textfieldTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
### What's in here?
- Update Demo and Lib to Xcode recommended settings
- Migrate Demo and Lib to Swift 5
- Update podspec


### Developer Notes
Until this PR is merged you can temporally use the following:
```
pod 'SwiftMaskTextfield', :git => 'git@github.com:Guerrix/swift-mask-textfield.git', :branch => 'feature/UpdateToSwift5'
```
After run `pod install` the error should go away and all should be good to 